### PR TITLE
hold reference to the world data instead of a copy

### DIFF
--- a/src/AStar2.cpp
+++ b/src/AStar2.cpp
@@ -179,7 +179,7 @@ CoordinateList PathFinder::findPath(Coord2D startPos, Coord2D goalPos)
 
 void PathFinder::exportPPM(const char *filename, CoordinateList* path)
 {
-    if (_world_data=nullptr)
+    if (_world_data==nullptr)
         return;
     
     std::ofstream outfile(filename, std::ios_base::out | std::ios_base::binary);


### PR DESCRIPTION
when profiling i can see that astar spends ~25% of its time copying in setWorldData()

since our system has dynamic obstacles, the world data is recalculated almost before every call to findPath() so that 25% is a big cost

since the caller must generate and hold the world data, i propose that the library receives a reference to the data instead of copying